### PR TITLE
 Set the default block size of nw to 64

### DIFF
--- a/rodinia/nw/nw.fut
+++ b/rodinia/nw/nw.fut
@@ -5,7 +5,6 @@
 --
 -- compiled input @ data/large.in.gz
 -- output @ data/large.out.gz
-
 -- compiled input @ data/tiny.in
 -- output @ data/tiny.out
 -- compiled input @ data/small.in
@@ -13,19 +12,20 @@
 -- compiled input @ data/medium.in.gz
 -- output @ data/medium.out.gz
 
-let B : i64 = 32
+let B0: i64 = 32
 
-let fInd (y:i32) (x:i32): i32 = y*(i32.i64 B+1) + x
+let fInd (B: i64) (y:i32) (x:i32): i32 = y*(i32.i64 B+1) + x
 let max3 (x:i32, y:i32, z:i32) = if x < y
                                  then if y < z then z else y
                                  else if x < z then z else x
-let mkVal [l2][l] (y:i32) (x:i32) (pen:i32) (inp_l:[l2]i32) (ref_l:[l][l]i32) : i32 = #[unsafe]
-  max3( ( (inp_l[fInd (y-1) (x-1)])) + ( ref_l[y-1, x-1])
-      , ( (inp_l[fInd y (x-1)])) - pen
-      , ( (inp_l[fInd (y-1) x])) - pen
+let mkVal [l2][l] (B: i64) (y:i32) (x:i32) (pen:i32) (inp_l:[l2]i32) (ref_l:[l][l]i32) : i32 = #[unsafe]
+  max3( ( (inp_l[fInd B (y-1) (x-1)])) + ( ref_l[y-1, x-1])
+      , ( (inp_l[fInd B y (x-1)])) - pen
+      , ( (inp_l[fInd B (y-1) x])) - pen
       )
 
-let intraBlockPar [lensq][len] (penalty: i32)
+let intraBlockPar [lensq][len] (B: i64)
+                               (penalty: i32)
                                (inputsets: [lensq]i32)
                                (reference2: [len][len]i32)
                                (b_y: i64) (b_x: i64)
@@ -65,8 +65,8 @@ let intraBlockPar [lensq][len] (penalty: i32)
                     if tx > m then (-1, 0)
                     else let ind_x = i32.i64 (tx + 1)
                          let ind_y = i32.i64 (m - tx + 1)
-                         let v = mkVal ind_y ind_x penalty inp_l ref_l
-                         in  (i64.i32 (fInd ind_y ind_x), v))))
+                         let v = mkVal B ind_y ind_x penalty inp_l ref_l
+                         in  (i64.i32 (fInd B ind_y ind_x), v))))
         in  scatter inp_l inds vals
 
   let inp_l = loop inp_l for m < B-1 do
@@ -76,8 +76,8 @@ let intraBlockPar [lensq][len] (penalty: i32)
                     if tx > m then (-1, 0)
                     else let ind_x = i32.i64 (tx + B - m)
                          let ind_y = i32.i64 (B - tx)
-                         let v = mkVal ind_y ind_x penalty inp_l ref_l
-                         in  (i64.i32 (fInd ind_y ind_x), v) )
+                         let v = mkVal B ind_y ind_x penalty inp_l ref_l
+                         in  (i64.i32 (fInd B ind_y ind_x), v) )
                 ) (iota B) )
         in  scatter inp_l inds vals
 
@@ -85,7 +85,8 @@ let intraBlockPar [lensq][len] (penalty: i32)
   in  inp_l2[1:B+1,1:B+1] :> [B][B]i32
 
 
-let updateBlocks [q][lensq] (len: i32) (blk: i64)
+let updateBlocks [q][lensq] (B: i64)
+                            (len: i32) (blk: i64)
                             (mk_b_y: (i32 -> i32))
                             (mk_b_x: (i32 -> i32))
                             (block_inp: [q][B][B]i32)
@@ -105,13 +106,14 @@ let updateBlocks [q][lensq] (len: i32) (blk: i64)
   in  scatter inputsets inds vals
 
 
--- `len-1` should be a multiple of 16
+-- `len-1` should be a multiple of B0
 let main [lensq] (penalty : i32)
                  (inputsets : *[lensq]i32)
                  (reference : *[lensq]i32) : *[lensq]i32 =
   let len = i32.f32 (f32.sqrt (f32.i64 lensq))
   let worksize = len - 1
-  let block_width = worksize / i32.i64 B
+  let B = i64.min (i64.i32 worksize) B0
+  let block_width = trace <| worksize / i32.i64 B
   let reference2 = unflatten (i64.i32 len) (i64.i32 len) reference
 
   -- First loop BEGINS
@@ -121,12 +123,12 @@ let main [lensq] (penalty : i32)
         let block_inp =
           tabulate blk (\b_x ->
                 let b_y = blk-1-b_x
-                in  intraBlockPar penalty inputsets reference2 b_y b_x
+                in  intraBlockPar B penalty inputsets reference2 b_y b_x
           )
 
         let mkBY bx = i32.i64 (blk - 1) - bx
         let mkBX bx = bx
-        in  updateBlocks len blk mkBY mkBX block_inp inputsets
+        in  updateBlocks B len blk mkBY mkBX block_inp inputsets
   -- First loop ENDS
 
   -- Second loop BEGINS
@@ -137,12 +139,12 @@ let main [lensq] (penalty : i32)
           tabulate blk (\bx ->
                 let b_y = i64.i32 block_width - 1 - bx
                 let b_x = bx + i64.i32 block_width - blk
-                in  intraBlockPar penalty inputsets reference2 b_y b_x
+                in  intraBlockPar B penalty inputsets reference2 b_y b_x
           )
 
         let mkBY bx = block_width - 1 - bx
         let mkBX bx = bx + block_width - i32.i64 blk
-        in  updateBlocks len blk mkBY mkBX block_inp inputsets
+        in  updateBlocks B len blk mkBY mkBX block_inp inputsets
     -- Second loop ENDS
 
   in  inputsets

--- a/rodinia/nw/nw.fut
+++ b/rodinia/nw/nw.fut
@@ -12,7 +12,7 @@
 -- compiled input @ data/medium.in.gz
 -- output @ data/medium.out.gz
 
-let B0: i64 = 32
+let B0: i64 = 64
 
 let fInd (B: i64) (y:i32) (x:i32): i32 = y*(i32.i64 B+1) + x
 let max3 (x:i32, y:i32, z:i32) = if x < y


### PR DESCRIPTION
This yields faster performance on almost all datasets and GPUs I have access to,
at the cost of using a bit more memory:

```
$ ~/src/futhark/tools/cmp-bench-json.py gpu04-{32,64}.json

nw.fut
  data/tiny.in:                                                         0.96x
  data/large.in:                                                        1.56x (mem: 1.01x@device)
  data/small.in:                                                        1.40x (mem: 1.11x@device)
  data/medium.in:                                                       1.42x (mem: 1.02x@device)

$ ~/src/futhark/tools/cmp-bench-json.py gpu03-{32,64}.json

nw.fut
  data/tiny.in:                                                         1.06x
  data/large.in:                                                        1.13x (mem: 1.01x@device)
  data/small.in:                                                        1.10x (mem: 1.11x@device)
  data/medium.in:                                                       1.14x (mem: 1.02x@device)

$ ~/src/futhark/tools/cmp-bench-json.py phi-{32,64}.json

nw.fut
  data/tiny.in:                                                         1.00x
  data/large.in:                                                        1.11x (mem: 1.01x@device)
  data/small.in:                                                        1.05x (mem: 1.11x@device)
  data/medium.in:                                                       1.14x (mem: 1.02x@device)
```