### PR TITLE
Simplify and clean up nw

### DIFF
--- a/rodinia/nw/nw.fut
+++ b/rodinia/nw/nw.fut
@@ -34,12 +34,8 @@ let intraBlockPar [lensq][len] (B: i64)
   -- for ( int ty = 0 ; ty < BLOCK_SIZE ; ty++)
   --   REF(ty, tx) =  reference_d[index + cols * ty];
 
-  let ref_l = replicate (B*B) 0
-  let ref_l = loop ref_l for i < B do
-                scatter ref_l (map (\tid->i*B+tid) (iota B))
-                        (tabulate B (\j -> reference2[i+b_y*B+1,
-                                                      b_x*B+1+j]))
-  let ref_l = unflatten B B ref_l
+  let ref_l = reference2[b_y * B + 1: b_y * B + 1 + B,
+                         b_x * B + 1: b_x * B + 1 + B] :> [B][B]i32
 
   let inp_l = replicate ((B+1)*(B+1)) 0i32
 


### PR DESCRIPTION
This PR cleans up NW a bit and makes it run faster in the process.

```
$ ~/src/futhark/tools/cmp-bench-json.py gpu04-{before,after}-everything.json

nw.fut
  data/tiny.in:                                                         1.36x (mem: 0.85x@device)
  data/large.in:                                                        1.46x (mem: 0.75x@device)
  data/small.in:                                                        1.15x (mem: 0.80x@device)
  data/medium.in:                                                       1.37x (mem: 0.76x@device)

$ ~/src/futhark/tools/cmp-bench-json.py gpu03-{before,after}-everything.json

nw.fut
  data/tiny.in:                                                         1.30x (mem: 0.85x@device)
  data/large.in:                                                        1.43x (mem: 0.75x@device)
  data/small.in:                                                        1.08x (mem: 0.80x@device)
  data/medium.in:                                                       1.16x (mem: 0.76x@device)

$ ~/src/futhark/tools/cmp-bench-json.py phi-{before,after}-everything.json

nw.fut
  data/tiny.in:                                                         1.25x (mem: 0.85x@device)
  data/large.in:                                                        1.36x (mem: 0.75x@device)
  data/small.in:                                                        0.95x (mem: 0.80x@device)
  data/medium.in:                                                       1.14x (mem: 0.76x@device)
```