### PR TITLE
Add nw.fut.tuning

### DIFF
--- a/rodinia/nw/nw.fut.tuning
+++ b/rodinia/nw/nw.fut.tuning
@@ -1,0 +1,6 @@
+main.suff_intra_par_0=16
+main.suff_intra_par_1=16
+main.suff_intra_par_2=16
+main.suff_intra_par_3=16
+main.suff_intra_par_4=64
+main.suff_intra_par_5=64


### PR DESCRIPTION
Tuning nw increases the performance on the tiny dataset:

```
[jxk588@gpu04:~/src/futhark]$ futhark bench --backend=opencl futhark-benchmarks/rodinia/nw/nw.fut
Compiling futhark-benchmarks/rodinia/nw/nw.fut...
Reporting average runtime of 10 runs for each dataset.

futhark-benchmarks/rodinia/nw/nw.fut (using nw.fut.tuning):
data/large.in:        3038μs (RSD: 0.008; min:  -0%; max:  +2%)
data/tiny.in:           40μs (RSD: 0.141; min: -15%; max: +36%)
data/small.in:         193μs (RSD: 0.020; min:  -2%; max:  +3%)
data/medium.in:       1986μs (RSD: 0.002; min:  -0%; max:  +0%)

[jxk588@gpu04:~/src/futhark]$ futhark bench --no-tuning --backend=opencl futhark-benchmarks/rodinia/nw/nw.fut
Compiling futhark-benchmarks/rodinia/nw/nw.fut...
Reporting average runtime of 10 runs for each dataset.

futhark-benchmarks/rodinia/nw/nw.fut:
data/large.in:        3038μs (RSD: 0.008; min:  -0%; max:  +2%)
data/tiny.in:          499μs (RSD: 0.027; min:  -4%; max:  +5%)
data/small.in:         191μs (RSD: 0.013; min:  -2%; max:  +2%)
data/medium.in:       1986μs (RSD: 0.002; min:  -0%; max:  +0%)
```