### PR TITLE
Add larger datasets for some benchmarks

### DIFF
--- a/accelerate/canny/canny.fut
+++ b/accelerate/canny/canny.fut
@@ -24,6 +24,8 @@
 --
 -- compiled input @ data/lena512.in
 -- output @ data/lena512.out
+--
+-- random input { 50f32 100f32 [8192][8192]i32 }
 
 let luminanceOfRGBA32(p: i32): f32 =
   let r = i8.i32(p >> 24)

--- a/accelerate/fft/fft.fut
+++ b/accelerate/fft/fft.fut
@@ -14,6 +14,9 @@
 -- output @ data/1024x1024.out
 -- compiled input @ data/128x128.in
 -- output @ data/128x128.out
+-- compiled random input { 10i32 [2048][2048][3]u8 }
+-- compiled random input { 10i32 [4096][4096][3]u8 }
+-- compiled random input { 10i32 [8192][8192][3]u8 }
 
 import "lib/github.com/diku-dk/complex/complex"
 

--- a/jgf/series/series.fut
+++ b/jgf/series/series.fut
@@ -12,6 +12,7 @@
 -- output @ data/100000.out
 -- compiled input @ data/1000000.in
 -- output @ data/1000000.out
+-- compiled input { 16777216i64 }
 
 let thefunction(x: f64, omegan: f64, select: i32): f64 =
   if select == 0 then (x+1.0) ** x

--- a/misc/ocean-sim/tridiag-test.fut
+++ b/misc/ocean-sim/tridiag-test.fut
@@ -4,12 +4,13 @@ import "tridiag"
 let INNER_DIM : i64 = 115
 
 -- ==
--- entry: tridagNested tridagNestedConst tridagNestedSeq tridagNestedSeqConst 
+-- entry: tridagNested tridagNestedConst tridagNestedSeq tridagNestedSeqConst
 --
 -- compiled input @ data/tridiag32-small.in
 -- output @ data/tridiag32-small.out
 --
 -- compiled random input { [57600][115]f32 [57600][115]f32 [57600][115]f32 [57600][115]f32 }
+-- compiled random input { [576000][115]f32 [576000][115]f32 [576000][115]f32 [576000][115]f32 }
 
 
 entry tridagNested [n][m] (a: [n][m]DTYPE) (b: [n][m]DTYPE) (c: [n][m]DTYPE) (y: [n][m]DTYPE): *[n][m]DTYPE =

--- a/parboil/sgemm/sgemm.fut
+++ b/parboil/sgemm/sgemm.fut
@@ -7,6 +7,7 @@
 -- output @ data/small.out
 -- compiled input @ data/medium.in.gz
 -- output @ data/medium.out.gz
+-- compiled random input { [8192][8192]f32 [8192][8192]f32 [8192][8192]f32 0.5f32 0.1f32 }
 
 let mult [n][m][p] (xss: [n][m]f32, yss: [m][p]f32): [n][p]f32 =
   let dotprod xs ys = f32.sum (map2 (*) xs ys)

--- a/parboil/sgemm/sgemm.fut.tuning
+++ b/parboil/sgemm/sgemm.fut.tuning
@@ -1,1 +1,2 @@
-default_threshold=10000
+main.suff_outer_par_0=2000000000
+main.suff_outer_par_1=50

--- a/rodinia/lavaMD/lavaMD-input.fut
+++ b/rodinia/lavaMD/lavaMD-input.fut
@@ -1,10 +1,10 @@
 ------------------------------------------
 -- Util: Sobol random number generation --
 ------------------------------------------
-let sobolDirVcts(): [30]i32 = 
-  [ 536870912, 268435456, 134217728, 67108864, 33554432, 16777216, 8388608, 4194304, 2097152, 1048576, 
-    524288,    262144,    131072,    65536,    32768,    16384,    8192,    4096,    2048,    1024, 
-    512,       256,       128,       64,       32,       16,       8,       4,       2,       1      ] 
+let sobolDirVcts(): [30]i32 =
+  [ 536870912, 268435456, 134217728, 67108864, 33554432, 16777216, 8388608, 4194304, 2097152, 1048576,
+    524288,    262144,    131072,    65536,    32768,    16384,    8192,    4096,    2048,    1024,
+    512,       256,       128,       64,       32,       16,       8,       4,       2,       1      ]
 
 let sobolInd(dirVct:  [30]i32, n: i64 ): i32 =
   let n_gray = (n >> 1) ^ n
@@ -17,34 +17,34 @@ let sobolInd(dirVct:  [30]i32, n: i64 ): i32 =
 
 -----------------------
 -----------------------
-let main (boxes1d: i64) (par_per_box: i64) (num_neighbors: i64):
+entry gen_input (number_boxes: i64) (par_per_box: i64) (num_neighbors: i64):
                         (f32,
-                         []i32,
-                         []i32,
-                         []i32,
-                         []i32,
+                         [number_boxes]i32,
+                         [number_boxes]i32,
+                         [number_boxes]i32,
+                         [number_boxes]i32,
 
-                         [][]i32,
-                         [][]i32,
-                         [][]i32,
-                         [][]i32,
+                         [num_neighbors][number_boxes]i32,
+                         [num_neighbors][number_boxes]i32,
+                         [num_neighbors][number_boxes]i32,
+                         [num_neighbors][number_boxes]i32,
 
-                         []i32,
+                         [number_boxes]i32,
 
-                         [][]f32,
-                         [][]f32,
-                         [][]f32,
-                         [][]f32,
+                         [number_boxes][par_per_box]f32,
+                         [number_boxes][par_per_box]f32,
+                         [number_boxes][par_per_box]f32,
+                         [number_boxes][par_per_box]f32,
 
-                         [][]f32) =
-  let number_boxes = boxes1d * boxes1d * boxes1d
+                         [number_boxes][par_per_box]f32) =
+  let boxes1d = i64.f64 (f64.i64 number_boxes ** (1f64/3f64))
   let alpha        = 0.5
   let dirVct       = sobolDirVcts()
 
   ----------------------------------------
   -- 1. Initialize boxs' data structure --
   ----------------------------------------
-  let boxes = 
+  let boxes =
     tabulate number_boxes
         (\nh  ->
           let k = nh % boxes1d
@@ -92,7 +92,7 @@ let main (boxes1d: i64) (par_per_box: i64) (num_neighbors: i64):
                            let s3= sobolInd(dirVct, n+2)
                            let s4= sobolInd(dirVct, n+3)
                            let s5= sobolInd(dirVct, n+4)
-                           in (f32.i32(s5%10 + 1) / 10.0, 
+                           in (f32.i32(s5%10 + 1) / 10.0,
                                ( f32.i32(s1%10 + 1) / 10.0, f32.i32(s2%10 + 1) / 10.0
                                , f32.i32(s3%10 + 1) / 10.0, f32.i32(s4%10 + 1) / 10.0 )
                               )

--- a/rodinia/lavaMD/lavaMD.fut
+++ b/rodinia/lavaMD/lavaMD.fut
@@ -6,6 +6,11 @@
 -- output @ data/3_boxes.out
 -- compiled input @ data/10_boxes.in.gz
 -- output @ data/10_boxes.out.gz
+-- compiled script input { gen_input 4096i64 512i64 100i64 }
+
+module Gen = import "lavaMD-input"
+
+entry gen_input = Gen.gen_input
 
 let dot ((ax,ay,az), (bx,by,bz)): f32 =
   ax*bx + ay*by + az*bz

--- a/rodinia/nn/nn.fut
+++ b/rodinia/nn/nn.fut
@@ -5,6 +5,9 @@
 --
 -- compiled input @ data/medium.in.gz
 -- output @ data/medium.out
+-- compiled random input { 100i32 30f32 90f32 [1710560]f32 [1710560]f32 }
+-- compiled random input { 100i32 30f32 90f32 [5710560]f32 [5710560]f32 }
+
 
 let emptyRecord: (i32, f32) = (0, 0.0f32)
 


### PR DESCRIPTION
Some of the datasets in our benchmark suite are way too small for modern GPUs
like the A100. I've tried to add a few new ones where it felt appropriate.

Some benchmarks that still have too small datasets are bfast (not cloudy) and
hashcat, but it seems like adding those is not as trivial.