### PR TITLE
Cleanup the lud code a bit

### DIFF
--- a/rodinia/lud/lud.fut
+++ b/rodinia/lud/lud.fut
@@ -15,67 +15,70 @@
 
 let dotprod [n] (a: [n]f32) (b: [n]f32): f32 =
   map2 (*) a b
-       |> reduce (+) 0
+  |> reduce (+) 0
 
 let lud_diagonal [b] (a: [b][b]f32): *[b][b]f32 =
-  map1 (\mat ->
-          let mat = copy mat
-          in loop (mat: *[b][b]f32) for i < b-1 do
-             let col = map (\j -> if j > i then
-                                    #[unsafe] (mat[j,i] - (dotprod mat[j,:i] mat[:i,i])) / mat[i,i]
-                                  else
-                                    mat[j,i])
-                           (iota b)
+  map (\mat ->
+         let mat = copy mat
+         in loop (mat: *[b][b]f32) for i < b-1 do
+            let col = map (\j -> if j > i then
+                                   #[unsafe] (mat[j,i] - (dotprod mat[j,:i] mat[:i,i])) / mat[i,i]
+                                 else
+                                   #[unsafe] mat[j,i])
+                          (iota b)
             let mat[:,i] = col
 
             let row = map (\j -> if j > i then
-                                   mat[i+1, j] - (dotprod mat[:i+1, j] mat[i+1, :i+1])
+                                   #[unsafe] mat[i+1, j] - (dotprod mat[:i+1, j] mat[i+1, :i+1])
                                  else
-                                   mat[i+1, j])
+                                   #[unsafe] mat[i+1, j])
                           (iota b)
             let mat[i+1] = row
 
             in mat
-       ) (unflatten (opaque 1) b a)
-       |> head
+      ) (unflatten (opaque 1) b a)
+  |> head
 
-let lud_perimeter_upper [m][b] (diag: [b][b]f32, a0s: [m][b][b]f32): *[m][b][b]f32 =
+let lud_perimeter_upper [m][b] (diag: [b][b]f32) (a0s: [m][b][b]f32): *[m][b][b]f32 =
     let a1s = map (\ (x: [b][b]f32): [b][b]f32  -> transpose(x)) a0s in
     let a2s =
-        map  (\a1: [b][b]f32  ->
-              map  (\row0: [b]f32  ->   -- Upper
-                    loop row = copy row0 for i < b do
-                    let sum = (loop sum=0.0f32 for k < i do sum + diag[i,k] * row[k])
-                    let row[i] = row[i] - sum
-                    in  row
+        map (\a1 ->
+               map (\row0 -> -- Upper
+                      #[unsafe]
+                      loop row = copy row0 for i < b do
+                      let sum = loop sum=0.0f32 for k < i do
+                                  sum + diag[i,k] * row[k]
+                      let row[i] = row[i] - sum
+                      in  row
                    ) a1
-             ) a1s
-    in map (\x: [b][b]f32 -> transpose(x)) a2s
+            ) a1s
+    in map transpose a2s
 
-let lud_perimeter_lower [b][m] (diag: [b][b]f32, mat: [m][b][b]f32): *[m][b][b]f32 =
-  map (\blk: [b][b]f32  ->
-        map  (\ (row0: [b]f32): *[b]f32  ->   -- Lower
+let lud_perimeter_lower [b][m] (diag: [b][b]f32) (mat: [m][b][b]f32): *[m][b][b]f32 =
+  map (\blk ->
+         map (\row0 -> -- Lower
+                #[unsafe]
                 loop row = copy row0 for j < b do
-                        let sum = loop sum=0.0f32 for k < j do
+                let sum = loop sum=0.0f32 for k < j do
                             sum + diag[k,j] * row[k]
-                        let row[j] = (row[j] - sum) / diag[j,j]
-                        in  row
-            ) blk
+                let row[j] = (row[j] - sum) / diag[j,j]
+                in  row
+             ) blk
       ) mat
 
-let lud_internal [m][b] (top_per: [m][b][b]f32, lft_per: [m][b][b]f32, mat_slice: [m][m][b][b]f32 ): *[m][m][b][b]f32 =
+let lud_internal [m][b] (top_per: [m][b][b]f32) (lft_per: [m][b][b]f32) (mat_slice: [m][m][b][b]f32): *[m][m][b][b]f32 =
   let top_slice = map transpose top_per in
-  map (\(mat_arr: [m][b][b]f32, lft: [b][b]f32): [m][b][b]f32  ->
-        map (\ (mat_blk: [b][b]f32, top: [b][b]f32): [b][b]f32  ->
-                map  (\ (mat_row: [b]f32, lft_row: [b]f32): [b]f32  ->
-                        map  (\(mat_el, top_row)  ->
+  map2 (\mat_arr lft ->
+        map2 (\mat_blk top ->
+                map2 (\mat_row lft_row ->
+                        map2 (\mat_el top_row ->
                                 let prods = map2 (*) lft_row top_row
-                                let sum   = f32.sum prods
+                                let sum = f32.sum prods
                                 in mat_el - sum
-                             ) (zip (mat_row) top)
-                    ) (zip (mat_blk) lft )
-           ) (zip (mat_arr) (top_slice) )
-     ) (zip (mat_slice) (lft_per) )
+                             ) mat_row top
+                    ) mat_blk lft
+           ) mat_arr top_slice
+     ) mat_slice lft_per
 
 let block_size: i64 = 32
 
@@ -95,35 +98,35 @@ let main [m] (mat: [m][m]f32): [m][m]f32 =
     ---- transform matrix in [n/b,n/b,b,b] block ----
     ---- versions for upper and lower parts      ----
     ---- the blocks of the lower part            ----
-    let matb =
-        map  (\i_b: [num_blocks][b][b]f32  ->
-                map  (\j_b: [b][b]f32  ->
+    let matb: *[num_blocks][num_blocks][b][b]f32 =
+        map (\i_b: [num_blocks][b][b]f32  ->
+                map (\j_b: [b][b]f32  ->
                         map (\i: [b]f32  ->
-                                map  (\j: f32  ->
+                                map (\j: f32  ->
                                         #[unsafe] mat[i_b*b+i, j_b*b + j]
-                                    ) (iota(b) )
-                           ) (iota(b) )
-                    ) (iota(num_blocks) )
-            ) (iota(num_blocks) )
+                                    ) (iota b)
+                           ) (iota b)
+                    ) (iota num_blocks)
+            ) (iota num_blocks)
 
-    let matb = loop(matb) for step < ((n / b) - 1) do
+    let matb = loop matb for step < (n / b) - 1 do
         -- 1. compute the current diagonal block
-        let diag = lud_diagonal(matb[step,step]) in
+        let diag = lud_diagonal matb[step,step] in
 
         -- 2. compute the top  perimeter
         let row_slice = matb[step,step+1:num_blocks]
-        let top_per_irreg = lud_perimeter_upper(diag, row_slice)
+        let top_per_irreg = lud_perimeter_upper diag row_slice
 
         -- 3. compute the left perimeter and update matrix
         let col_slice = matb[step+1:num_blocks,step]
-        let lft_per_irreg = lud_perimeter_lower(diag, col_slice)
+        let lft_per_irreg = lud_perimeter_lower diag col_slice
 
         -- 4. compute the internal blocks
         let inner_slice = matb[step+1:num_blocks,step+1:num_blocks]
-        let internal = lud_internal(top_per_irreg, lft_per_irreg, inner_slice)
+        let internal = lud_internal top_per_irreg lft_per_irreg inner_slice
 
         -- 5. update matrix in place
-        let matb[step,step] = diag
+        let matb[step, step] = diag
         let matb[step, step+1:num_blocks] = top_per_irreg
         let matb[step+1:num_blocks, step] = lft_per_irreg
         let matb[step+1:num_blocks, step+1:num_blocks] = internal
@@ -131,7 +134,7 @@ let main [m] (mat: [m][m]f32): [m][m]f32 =
 
     let last_step = (n / b) - 1 in
     let matb[last_step,last_step] =
-            lud_diagonal( matb[last_step, last_step] )
+      lud_diagonal matb[last_step, last_step]
 
     let ret_padded = map (\i_ind  ->
                           map  (\j_ind  ->

--- a/rodinia/lud/lud.fut
+++ b/rodinia/lud/lud.fut
@@ -20,18 +20,19 @@ let dotprod [n] (a: [n]f32) (b: [n]f32): f32 =
 let lud_diagonal [b] (a: [b][b]f32): *[b][b]f32 =
   map (\mat ->
          let mat = copy mat
-         in loop (mat: *[b][b]f32) for i < b-1 do
+         in #[unsafe]
+            loop (mat: *[b][b]f32) for i < b-1 do
             let col = map (\j -> if j > i then
-                                   #[unsafe] (mat[j,i] - (dotprod mat[j,:i] mat[:i,i])) / mat[i,i]
+                                   (mat[j,i] - (dotprod mat[j,:i] mat[:i,i])) / mat[i,i]
                                  else
-                                   #[unsafe] mat[j,i])
+                                   mat[j,i])
                           (iota b)
             let mat[:,i] = col
 
             let row = map (\j -> if j > i then
-                                   #[unsafe] mat[i+1, j] - (dotprod mat[:i+1, j] mat[i+1, :i+1])
+                                   mat[i+1, j] - (dotprod mat[:i+1, j] mat[i+1, :i+1])
                                  else
-                                   #[unsafe] mat[i+1, j])
+                                   mat[i+1, j])
                           (iota b)
             let mat[i+1] = row
 


### PR DESCRIPTION
This cleanup results in significant performance improvements for LUD, both using the master branch of futhark and using the old-coalesce branch:

```
$ tools/cmp-bench-json.py lud-master.before-cleanup lud-master.after-cleanup

futhark-benchmarks/rodinia/lud/lud.fut
  data/16by16.in:                                                       1.09x
  data/2048.in:                                                         1.24x
  data/256.in:                                                          1.29x
  data/512.in:                                                          1.30x
  data/64.in:                                                           1.22x
```

```
$ tools/cmp-bench-json.py lud.before-cleanup lud.after-cleanup

futhark-benchmarks/rodinia/lud/lud.fut
  data/16by16.in:                                                       1.07x
  data/2048.in:                                                         1.23x
  data/256.in:                                                          1.27x
  data/512.in:                                                          1.28x
  data/64.in:                                                           1.20x
```

Both of those are with 1000 runs on the A100, with only the 16by16 results not being statistically significant.