### PR TITLE
macOS compatibility

### DIFF
--- a/add-data.sh
+++ b/add-data.sh
@@ -13,7 +13,7 @@ if [ $# != 2 ]; then
     exit 1
 fi
 
-SHA=$(curl "$1" | sha256sum - | cut -f 1 -d ' ')
+SHA=$(curl "$1" | shasum -a 256 - | cut -f 1 -d ' ')
 
 ln -s -r "external-data/$2" "$2"
 

--- a/add-data.sh
+++ b/add-data.sh
@@ -13,7 +13,7 @@ if [ $# != 2 ]; then
     exit 1
 fi
 
-SHA=$(curl "$1" | shasum -a 256 - | cut -f 1 -d ' ')
+SHA=$(curl "$1" | LC_ALL=en_US.UTF-8 shasum -a 256 - | cut -f 1 -d ' ')
 
 ln -s -r "external-data/$2" "$2"
 

--- a/get-data.sh
+++ b/get-data.sh
@@ -37,13 +37,15 @@ if [ -z "$(which curl)" ]; then
     exit 5
 fi
 
+function sha256sum() { LC_ALL=C shasum -a 256 "$@" ; }
+
 BASEDIR=$(dirname "$1")
 
 while read -r OUTPUT URL CHECKSUM; do
     echo "Now processing $OUTPUT..."
 
     if [ -f "$OUTPUT" ]; then
-        COMPUTED_SUM=$(shasum -a 256 "$OUTPUT" | cut -f 1 -d ' ')
+        COMPUTED_SUM=$(sha256sum "$OUTPUT" | cut -f 1 -d ' ')
         if [ "$COMPUTED_SUM" = "$CHECKSUM" ]; then
             echo "File exists. Skipping."
             continue
@@ -57,7 +59,7 @@ while read -r OUTPUT URL CHECKSUM; do
 
     TMPFILE=$(mktemp)
     curl --fail "$URL" --output "$TMPFILE"
-    COMPUTED_SUM=$(shasum -a 256 "$TMPFILE" | cut -f 1 -d ' ')
+    COMPUTED_SUM=$(sha256sum "$TMPFILE" | cut -f 1 -d ' ')
 
     if [ "$COMPUTED_SUM" = "$CHECKSUM" ]; then
         mkdir -p "${BASEDIR}/$(dirname "$OUTPUT")"

--- a/get-data.sh
+++ b/get-data.sh
@@ -25,8 +25,8 @@ if [ "$#" -ne "1" ]; then
     exit 3
 fi
 
-if [ -z "$(which sha256sum)" ]; then
-    echo "Error: sha256sum could not be found."
+if [ -z "$(which shasum)" ]; then
+    echo "Error: shasum could not be found."
 
     exit 4
 fi
@@ -43,7 +43,7 @@ while read -r OUTPUT URL CHECKSUM; do
     echo "Now processing $OUTPUT..."
 
     if [ -f "$OUTPUT" ]; then
-        COMPUTED_SUM=$(sha256sum "$OUTPUT" | cut --fields=1 --delimiter=' ')
+        COMPUTED_SUM=$(shasum -a 256 "$OUTPUT" | cut -f 1 -d ' ')
         if [ "$COMPUTED_SUM" = "$CHECKSUM" ]; then
             echo "File exists. Skipping."
             continue
@@ -57,10 +57,10 @@ while read -r OUTPUT URL CHECKSUM; do
 
     TMPFILE=$(mktemp)
     curl --fail "$URL" --output "$TMPFILE"
-    COMPUTED_SUM=$(sha256sum "$TMPFILE" | cut --fields=1 --delimiter=' ')
+    COMPUTED_SUM=$(shasum -a 256 "$TMPFILE" | cut -f 1 -d ' ')
 
     if [ "$COMPUTED_SUM" = "$CHECKSUM" ]; then
-        mkdir --parents "${BASEDIR}/$(dirname "$OUTPUT")"
+        mkdir -p "${BASEDIR}/$(dirname "$OUTPUT")"
         mv "$TMPFILE" "${BASEDIR}/${OUTPUT}"
     else
         echo "Error: Invalid checksum of downloaded file!"


### PR DESCRIPTION
This patch makes the `get-data.sh` and `add-data.sh` scripts compatible with macOS.

Tested on macOS 12.2.1 and Red Hat Enterprise Linux 8.3 (`futharkhpa01fl` at DIKU).