### PR TITLE
Use NW from futhark-mem-sc22

### DIFF
--- a/rodinia/nw/intrinsics.fut
+++ b/rodinia/nw/intrinsics.fut
@@ -1,0 +1,17 @@
+def flat_index_2d [n] 'a (as: [n]a) (offset: i64) (n1: i64) (s1: i64) (n2: i64) (s2: i64) : [n1][n2]a =
+  intrinsics.flat_index_2d(as, offset, n1, s1, n2, s2) :> [n1][n2]a
+
+def flat_update_2d [n][k][l] 'a (as: *[n]a) (offset: i64) (s1: i64) (s2: i64) (asss: [k][l]a) : *[n]a =
+  intrinsics.flat_update_2d(as, offset, s1, s2, asss)
+
+def flat_index_3d [n] 'a (as: [n]a) (offset: i64) (n1: i64) (s1: i64) (n2: i64) (s2: i64) (n3: i64) (s3: i64) : [n1][n2][n3]a =
+  intrinsics.flat_index_3d(as, offset, n1, s1, n2, s2, n3, s3) :> [n1][n2][n3]a
+
+def flat_update_3d [n][k][l][p] 'a (as: *[n]a) (offset: i64) (s1: i64) (s2: i64) (s3: i64) (asss: [k][l][p]a) : *[n]a =
+  intrinsics.flat_update_3d(as, offset, s1, s2, s3, asss)
+
+def flat_index_4d [n] 'a (as: [n]a) (offset: i64) (n1: i64) (s1: i64) (n2: i64) (s2: i64) (n3: i64) (s3: i64) (n4: i64) (s4: i64) : [n1][n2][n3][n4]a =
+  intrinsics.flat_index_4d(as, offset, n1, s1, n2, s2, n3, s3, n4, s4) :> [n1][n2][n3][n4]a
+
+def flat_update_4d [n][k][l][p][q] 'a (as: *[n]a) (offset: i64) (s1: i64) (s2: i64) (s3: i64) (s4: i64) (asss: [k][l][p][q]a) : *[n]a =
+  intrinsics.flat_update_4d(as, offset, s1, s2, s3, s4, asss)

--- a/rodinia/nw/nw.fut
+++ b/rodinia/nw/nw.fut
@@ -2,153 +2,142 @@
 -- https://github.com/kkushagra/rodinia/blob/master/openmp/nw
 --
 -- ==
---
+-- compiled input @ data/medium.in.gz
+-- output @ data/medium.out.gz
 -- compiled input @ data/large.in.gz
 -- output @ data/large.out.gz
+
+-- These are too small for the assertions and block size:
 -- compiled input @ data/tiny.in
 -- output @ data/tiny.out
 -- compiled input @ data/small.in
 -- output @ data/small.out
--- compiled input @ data/medium.in.gz
--- output @ data/medium.out.gz
 
-def B0: i64 = 64
+entry mk_input (row_length: i64) =
+  let n = (row_length + 1)**2
+  in (10i32, replicate n 0i32 , replicate n 0i32)
 
-def fInd (B: i64) (y:i32) (x:i32): i32 = y*(i32.i64 B+1) + x
-def max3 (x:i32, y:i32, z:i32) = if x < y
-                                 then if y < z then z else y
-                                 else if x < z then z else x
-def mkVal [l2][l] (y:i32) (x:i32) (pen:i32) (inp_l:[l2][l2]i32) (ref_l:[l][l]i32) : i32 = #[unsafe]
-  max3( ( (inp_l[y - 1, x - 1])) + ( ref_l[y-1, x-1])
-      , ( (inp_l[y, x - 1])) - pen
-      , ( (inp_l[y - 1, x])) - pen
-      )
+import "intrinsics"
 
-def intraBlockPar [len] (B: i64)
-                               (penalty: i32)
-                               (inputsets: [len][len]i32)
-                               (reference2: [len][len]i32)
-                               (b_y: i64) (b_x: i64)
-                               : [B][B]i32 =
-  let ref_l = reference2[b_y * B + 1: b_y * B + 1 + B,
-                         b_x * B + 1: b_x * B + 1 + B] :> [B][B]i32
+let mkVal [bp1][b] (y:i32) (x:i32) (pen:i32) (block:[bp1][]i32) (ref:[b][b]i32) : i32 =
+  #[unsafe]
+  i32.max (block[y, x - 1] - pen) (block[y - 1, x] - pen)
+  |> i32.max (block[y - 1, x - 1] + ref[y - 1, x - 1])
 
-  -- inp_l is the working memory
-  let inp_l = replicate ((B+1)*(B+1)) 0i32
-              |> unflatten (B+1) (B+1)
+let process_block [b][bp1]
+                  (penalty: i32)
+                  (above: [bp1]i32)
+                  (left: [b]i32)
+                  (ref: [b][b]i32): *[b][b]i32 =
+  let block = assert (b + 1 == bp1) (tabulate_2d bp1 (bp1+1) (\_ _ -> 0))
+  let block[0, 0:bp1] = above
+  let block[1:, 0] = left
 
-  -- Initialize inp_l with the already processed the column to the left of this
-  -- block
-  let inp_l[0:B+1, 0] = inputsets[b_y * B : b_y * B + B + 1, b_x * B]
-
-  -- Initialize inp_l with the already processed the row to above this block
-  let inp_l[0, 1:B+1] = inputsets[b_y * B, b_x * B + 1 : b_x * B + B + 1]
+  let ref_block = copy (opaque ref)
+  let ref_block[0,0] = opaque ref_block[0,0]
+  let ref = ref_block
 
   -- Process the first half (anti-diagonally) of the block
-  let inp_l = loop inp_l for m < B do
+  let block =
+    loop block for m < b do
        let inds =
-            -- tabulate over the m'th anti-diagonal before the middle
-            tabulate B (\tx ->  (
-                    if tx > m then (-1, -1)
-                    else let ind_x = i32.i64 (tx + 1)
-                         let ind_y = i32.i64 (m - tx + 1)
-                         in  (i64.i32 ind_y, i64.i32 ind_x)))
+            tabulate b (\tx ->
+                          if tx > m then (-1, -1)
+                          else let ind_x = i32.i64 (tx + 1)
+                               let ind_y = i32.i64 (m - tx + 1)
+                               in (i64.i32 ind_y, i64.i32 ind_x))
         let vals =
             -- tabulate over the m'th anti-diagonal before the middle
-            tabulate B (\tx ->  (
-                    if tx > m then 0
-                    else let ind_x = i32.i64 (tx + 1)
-                         let ind_y = i32.i64 (m - tx + 1)
-                         let v = mkVal ind_y ind_x penalty inp_l ref_l
-                         in  v))
-        in  scatter_2d inp_l inds vals
+            tabulate b
+                     (\tx ->
+                        if tx > m then 0
+                        else let ind_x = i32.i64 (tx + 1)
+                             let ind_y = i32.i64 (m - tx + 1)
+                             let v = mkVal ind_y ind_x penalty block ref
+                             in v)
+        in scatter_2d block inds vals
 
   -- Process the second half (anti-diagonally) of the block
-  let inp_l = loop inp_l for m < B-1 do
-        let m = B - 2 - m
-        let inds = tabulate B (\tx ->  (
+  let block = loop block for m < b-1 do
+        let m = b - 2 - m
+        let inds = tabulate b (\tx ->  (
                     if tx > m then (-1, -1)
-                    else let ind_x = i32.i64 (tx + B - m)
-                         let ind_y = i32.i64 (B - tx)
+                    else let ind_x = i32.i64 (tx + b - m)
+                         let ind_y = i32.i64 (b - tx)
                          in  ((i64.i32 ind_y, i64.i32 ind_x)) )
                 )
         let vals =
             -- tabulate over the m'th anti-diagonal after the middle
-            tabulate B (\tx ->  (
+            tabulate b (\tx ->  (
                     if tx > m then (0)
-                    else let ind_x = i32.i64 (tx + B - m)
-                         let ind_y = i32.i64 (B - tx)
-                         let v = mkVal ind_y ind_x penalty inp_l ref_l
+                    else let ind_x = i32.i64 (tx + b - m)
+                         let ind_y = i32.i64 (b - tx)
+                         let v = mkVal ind_y ind_x penalty block ref
                          in  v ))
-        in  scatter_2d inp_l inds vals
+        in scatter_2d block inds vals
 
-  let inp_l2 = inp_l
-  in  inp_l2[1:B+1,1:B+1] :> [B][B]i32
+  in block[1:, 1:bp1] :> *[b][b]i32
 
+def main_flat [n]
+         (penalty: i32)
+         (input: *[n]i32)
+         (refs: [n]i32)
+         : *[n]i32 =
+  let block_size = 64
+  let row_length = i64.f64 <| f64.sqrt <| f64.i64 n
+  let num_blocks = assert ((row_length - 1) % block_size == 0)
+                          ((assert (row_length > block_size * 3) row_length - 1) / block_size)
+  let bp1 = assert (row_length > 3) (assert (2 * block_size < row_length) (block_size + 1))
 
-def updateBlocks [q][len] (B: i64)
-                            (blk: i64)
-                            (mk_b_y: (i32 -> i32))
-                            (mk_b_x: (i32 -> i32))
-                            (block_inp: [q][B][B]i32)
-                            (inputsets:  *[len][len]i32) =
-  let (inds, vals) = unzip (
-    tabulate (blk*B*B) (\gid ->
-                 let B2 = i32.i64 (B*B)
-                 let gid = i32.i64 gid
-                 let (bx, lid2) = (gid / B2, gid % B2)
-                 let (ty, tx)   = (lid2 / i32.i64 B, lid2 % i32.i64 B)
+  let input =
+    loop input for i < num_blocks do
+    let ip1 = i + 1
+    let v =
+      #[incremental_flattening(only_intra)]
+      map3 (process_block penalty)
+      (flat_index_2d input (i * block_size)
+                     ip1 (row_length * block_size - block_size)
+                     bp1 1)
+      (flat_index_2d input (row_length + i * block_size)
+                     ip1 (row_length * block_size - block_size)
+                     block_size row_length)
+      (flat_index_3d refs (row_length + 1 + i * block_size)
+                     ip1 (row_length * block_size - block_size)
+                     block_size row_length
+                     block_size 1i64)
+    in flat_update_3d
+         input
+         (row_length + 1 + i * block_size)
+         (row_length * block_size - block_size)
+         (row_length)
+         1
+         v
 
-                 let b_y = mk_b_y bx
-                 let b_x = mk_b_x bx
-                 let v = #[unsafe] block_inp[bx, ty, tx]
-                 in  ((i64.i32 (i32.i64 B*b_y + 1 + ty),
-                       i64.i32 (i32.i64 B*b_x + tx + 1)),
-                      v)))
-  in  scatter_2d inputsets inds vals
+  let input =
+    loop input for i < num_blocks - 1 do
+    let v =
+      #[incremental_flattening(only_intra)]
+      map3 (process_block penalty)
+      (flat_index_2d input (((i + 1) * block_size + 1) * row_length - block_size - 1)
+                     (num_blocks - i - 1) (row_length * block_size - block_size)
+                     bp1 1i64)
+      (flat_index_2d input (((i + 1) * block_size + 1) * row_length - block_size - 1 + row_length)
+                     (num_blocks - i - 1) (row_length * block_size - block_size)
+                     block_size row_length)
+      (flat_index_3d refs (((i + 1) * block_size + 2) * row_length - block_size)
+                     (num_blocks - i - 1) (row_length * block_size - block_size)
+                     block_size row_length
+                     block_size 1i64)
+    in flat_update_3d
+         input
+         (((i + 1) * block_size + 2) * row_length - block_size)
+         (row_length * block_size - block_size)
+         (row_length)
+         1
+         v
 
+  in input
 
-def main [len] (penalty : i32)
-                 (inputsets : *[len][len]i32)
-                 (reference : *[len][len]i32) : *[len][len]i32 =
-  #[unsafe]
-  let worksize = len - 1
-  let B = i64.min worksize B0
-
-  -- worksize should be a multiple of B0
-  let B = assert (worksize % B == 0) B
-
-  let block_width = i32.i64 <| worksize / B
-
-  -- First anti-diagonal half of the entire input matrix
-  let inputsets =
-    loop inputsets for blk < block_width do
-        let blk = i64.i32 (blk + 1)
-        let block_inp =
-          -- Process an anti-diagonal of independent blocks
-          tabulate blk (\b_x ->
-                let b_y = blk-1-b_x
-                in  intraBlockPar B penalty inputsets reference b_y b_x
-          )
-
-        let mkBY bx = i32.i64 (blk - 1) - bx
-        let mkBX bx = bx
-        in  updateBlocks B blk mkBY mkBX block_inp inputsets
-
-  -- Second anti-diagonal half of the entire input matrix
-  let inputsets =
-    loop inputsets for blk < block_width-1 do
-        let blk = i64.i32 (block_width - 1 - blk)
-        let block_inp =
-          -- Process an anti-diagonal of independent blocks
-          tabulate blk (\bx ->
-                let b_y = i64.i32 block_width - 1 - bx
-                let b_x = bx + i64.i32 block_width - blk
-                in  intraBlockPar B penalty inputsets reference b_y b_x
-          )
-
-        let mkBY bx = block_width - 1 - bx
-        let mkBX bx = bx + block_width - i32.i64 blk
-        in  updateBlocks B blk mkBY mkBX block_inp inputsets
-
-  in inputsets
+def main [n] (penalty: i32) (input: *[n][n]i32) (refs: [n][n]i32) : *[n][n]i32 =
+  let k = n*n
+  in main_flat penalty (flatten_to k input) (flatten_to k refs) |> unflatten n n

--- a/rodinia/nw/nw.fut.tuning
+++ b/rodinia/nw/nw.fut.tuning
@@ -1,6 +1,0 @@
-main.suff_intra_par_0=16
-main.suff_intra_par_1=16
-main.suff_intra_par_2=16
-main.suff_intra_par_3=16
-main.suff_intra_par_4=64
-main.suff_intra_par_5=64


### PR DESCRIPTION
This version of NW is faster, even though short-circuiting doesn't currently apply. I'm not sure why.

The downside is that the new version doesn't support the smallest datasets, but they are so small as to be insignificant anyway.

```console
$ ~/src/futhark/tools/cmp-bench-json.py {old,new}.json
In old.json but not new.json: program rodinia/nw/nw.fut dataset data/small.in
In old.json but not new.json: program rodinia/nw/nw.fut dataset data/tiny.in

rodinia/nw/nw.fut
  data/large.in:                                                        1.15x (mem: 1.47x@device)
  data/medium.in:                                                       1.32x (mem: 1.45x@device)
```